### PR TITLE
fix edgecase

### DIFF
--- a/lib/counter_web/live/counter.ex
+++ b/lib/counter_web/live/counter.ex
@@ -32,6 +32,10 @@ defmodule CounterWeb.Counter do
     {:noreply, assign(socket, val: count)}
   end
 
+  def handle_info(%{event: "presence_diff", payload: %{joins: joins}}, socket)
+      when is_map_key(joins, socket.id),
+      do: {:noreply, socket}
+
   def handle_info(
         %{event: "presence_diff", payload: %{joins: joins, leaves: leaves}},
         %{assigns: %{present: present}} = socket


### PR DESCRIPTION
Dealing with errors where counters are off-by-one :-)

The issue here is you're counting yourself twice initially, where you do subscribe on mount and then also act the propagated "joined" event of yourself in the `handle_info` callback!

(This doesn't amount to `4` with two clients open, since both start out at two and then receive the joined event from each other once, so you only get a `3` instead. The implementation to keep track of presence users also uses a `Map` data structure, which itself guarantees _unique_ keys, and putting the same key/value into a map automatically results in last-one-wins instead of duplication: this property is lost when you only inc/dec a number in your code.) 

Fixing this is handling the edgecase of your self-join situation. The idiomatic way in elixir here is not by starting if/else chain _in the function_, but _pattern match_ the exact constellation and dealing with that situation only (in this case by doing nothing). This makes the edgecase explicit & obvious for readers and doesn't even touch the already existing (working!) code at all. Think of it of a very literal way of overloading without the fuzz, that at runtime is optimized into a direct `jump` with O(1) no matter how many patterns you have :-) 

Cheers man, and welcome in Elixir world, fellow alchemist! 